### PR TITLE
bug: Use item value directly

### DIFF
--- a/base64.js
+++ b/base64.js
@@ -21,14 +21,11 @@ function output(target, value) {
 }
 
 function get(target) {
+    let t = document.getElementsByName(target)[0];
     try {
-        let t = document.getElementsByName(target)[0];
-        if (t.attributes.hasOwnProperty('value')) {
-            return t.value;
-        }
-        return t.innerHTML;
+        return t.value;
     } catch (TypeError) {
-        return null;
+        return t.innerHTML;
     }
 
 }


### PR DESCRIPTION
The page made an incorrect assumption about how attributes worked for textareas.

Fixes #7
